### PR TITLE
Fix code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/controllers/login.js
+++ b/controllers/login.js
@@ -8,15 +8,15 @@
  const saltrounds = 10
  router.post('/', async(request,response)=>{
     const body = request.body
-    console.log(request.body)
+    // console.log(request.body) // Removed to avoid logging sensitive information
     const user = await User.findOne({
         where:{
             username:body.username,
         }
     });
-    console.log(user)
+    // console.log(user) // Removed to avoid logging sensitive information
     const passwordcorrect = user===null? false: await bcrypt.compare(body.password,user.hashedpassword);
-    console.log(passwordcorrect)
+    // console.log(passwordcorrect) // Removed to avoid logging sensitive information
     if(!(user && passwordcorrect)){
         return response.status(401).json({
             error:'invalid username or password'
@@ -28,7 +28,7 @@
         passord:user.hashedpassword,
     }
     const token = jwt.sign(userForToken,process.env.SECRET,{expiresIn:60*60})
-    console.log(token)
+    // console.log(token) // Removed to avoid logging sensitive information
     return response
         .status(200)
         .send({token,username:user.username})


### PR DESCRIPTION
Fixes [https://github.com/gerick23/WorldofwarshipssiteBackend/security/code-scanning/3](https://github.com/gerick23/WorldofwarshipssiteBackend/security/code-scanning/3)

To fix the problem, we should remove the logging of sensitive information such as `passwordcorrect`, `request.body`, `user`, and `token`. These logs can expose sensitive data and should not be present in the code. Instead, we can log generic messages that do not contain sensitive information.

- Remove or replace the `console.log` statements that log sensitive information.
- Ensure that no sensitive data is logged at any point in the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
